### PR TITLE
Feature/s3

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -43,6 +43,8 @@ class BoothSerializer(serializers.ModelSerializer):
 
 
 class BoothMenuSerializer(serializers.ModelSerializer):
+    file = serializers.FileField(required=False, write_only=True)  # file 필드 추가
+
     class Meta:
         model = BoothMenu
         fields = '__all__'
@@ -69,7 +71,18 @@ class BoothMenuSerializer(serializers.ModelSerializer):
             price=validated_data['price'],
             description=validated_data['description'],
         )
+
         return booth_menu
+
+    def update(self, instance, validated_data):
+        file = validated_data.pop('file', None)  # file 필드 제거
+        for (key, value) in validated_data.items():
+            setattr(instance, key, value)
+        if file:
+            # 파일 업로드 로직 추가 가능
+            pass
+        instance.save()
+        return instance
 
 
 class TableSerializer(serializers.ModelSerializer):

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -245,3 +245,10 @@ CACHES = {
         'LOCATION': 'unique-snowflake',
     }
 }
+
+# S3 setting
+AWS_ACCESS_KEY_ID = get_secret("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = get_secret("AWS_SECRET_ACCESS_KEY")
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', 'hiccorder2')
+AWS_S3_REGION_NAME = os.environ.get('AWS_S3_REGION_NAME', 'ap-northeast-2')
+IMAGE_URL = "https://%s.s3.%s.amazonaws.com/" % (AWS_STORAGE_BUCKET_NAME, AWS_S3_REGION_NAME)


### PR DESCRIPTION
# 작업 이름 (s3 이미지 파일 업로드 및 url 저장 구현)


## 주요 변경 내용
- s3 사용을 위한 setting 설정 
- booth.py에서 기능 추가
- serializer 수정

## 참고 사항
-

## 남은 작업 내용
-

## 참고용 시연 사진
- 부스 이미지 파일 patch 시연


부스 이미지로 올리려는 사진 예시

![hicc 홈페이지](https://github.com/user-attachments/assets/7ba3a337-bc98-4352-9ff9-32192bbcf404)



해당 이미지와 함께 db에 데이터를 patch

![2024-08-07 03;28;38](https://github.com/user-attachments/assets/4f9dad85-6f9e-435e-a723-f40b4c76ab29)



s3의 실제 버킷에 이미지가 저장된 모습

![2024-08-07 03;29;33](https://github.com/user-attachments/assets/08801b6e-1a36-46e1-a7b6-1d20092e4f08)



데이터를 GET 요청 하면 해당 이미지의 URL을 불러올 수 있음

![2024-08-07 03;28;54](https://github.com/user-attachments/assets/76a3eba3-c1bd-436a-96e1-465b70135dd5)



URL에 실제로 접속하면 예시의 이미지가 나옴

![2024-08-07 03;29;48](https://github.com/user-attachments/assets/889eaf24-a590-4bc6-b737-3527c41cfbcb)



- 메뉴 이미지 파일 patch 시연

![ramen2](https://github.com/user-attachments/assets/8a0089b5-9705-43db-9742-9b7c66a83c25)
![2024-08-07 03;23;40](https://github.com/user-attachments/assets/9d7ca7f2-3a05-4ed6-8c57-a8cce3724b43)
![2024-08-07 03;24;46](https://github.com/user-attachments/assets/b1a50aa4-4b47-4ebb-955f-3133723e3768)
![2024-08-07 03;24;00](https://github.com/user-attachments/assets/c2417f51-48d3-4f19-8ac8-da0b7044c5d9)
![2024-08-07 03;25;00](https://github.com/user-attachments/assets/37443860-96de-4b57-9124-63357312f38c)

